### PR TITLE
Fix veryfying if git log is decodable in utf-8

### DIFF
--- a/common.py
+++ b/common.py
@@ -205,9 +205,12 @@ def verifyGitStatusFiles (report, package, releaseTagStr):
 		report.passed("Verification of git status files PASSED")
 
 def sanitizePackageLog(log, report = None):
+	try:
+		log.decode('utf-8')
+	except UnicodeDecodeError:
+		if report != None:
+			report.warning("git log contains non-decodable symbols")
 	slog = log.decode('utf-8', 'ignore')
-	if report != None and slog != log:
-		report.warning("git log contains non-decodable symbols")
 	slog = slog.replace('\r\n', '\n')
 	slog = slog.replace('\t', '        ')
 	slog = re.sub(' \(.*(tag: .*)+\)', '', slog)


### PR DESCRIPTION
It seems in Python3, bytes object cannot be directly
compared to string - this always return False.

Instead of such comparison, try
decoding bytes object to utf-8 without 'ignore' flag
and see if this throws and exception. If it throws,
than it meand bytes were not dedocable do utf-8.