### PR TITLE
Verification needs to pull mustpass from "main" and not "master".

### DIFF
--- a/verify_vk.py
+++ b/verify_vk.py
@@ -30,7 +30,7 @@ from log_parser import StatusCode, BatchResultParser
 
 def getMustpassDir(api, releaseTagStr):
 
-	mustpassDir = 'master'
+	mustpassDir = 'main'
 	matchFound = False
 	for r in NOT_MASTER_DIR:
 		if re.match(r, releaseTagStr):


### PR DESCRIPTION
This is needed to get the verification scripts to work with the new location of the mustpass files. @mnetsch I guess there might need to be something more complicated than this simple fix to handle old submissions that still have the mustpass located in "master"?
