### PR TITLE
make verify_submission.py read packageFile from args

### DIFF
--- a/verify_submission.py
+++ b/verify_submission.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 	ctsPath			= validateSource(args.source)
 	report			= Report(args.verbose, args.output)
 
-	packageFile		= os.path.normpath(sys.argv[1])
+	packageFile		= os.path.normpath(args.package)
 	packagePath		= args.untarDir
 	packageFileBN	= os.path.basename(packageFile)
 


### PR DESCRIPTION
This matches documentation (--help) and makes it possible to use other parameters like -o or -s.
    
