### PR TITLE
utils: U is not a valid option for open anymore

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -191,7 +191,7 @@ def beginsWith (str, prefix):
 	return str[:len(prefix)] == prefix
 
 def readFile (filename):
-	f = open(filename, 'rbU')
+	f = open(filename, 'rb')
 	data = f.read()
 	f.close()
 	return data


### PR DESCRIPTION
Has been deprecated for some time (so we got a warning), on recent version of python3 it doesn't even recognized.

    f = open(filename, 'rbU')
        ^^^^^^^^^^^^^^^^^^^^^
    ValueError: invalid mode: 'rbU'