### PR TITLE
Conditionally set the search path for es mustpass files

### DIFF
--- a/verify_es.py
+++ b/verify_es.py
@@ -200,9 +200,29 @@ def verifyTestLogs(report, package, gitSHA, ctsPath):
 	verifyConfigFile(report, os.path.join(package.basePath, summary.configLogFilename), summary.type)
 
 	mustpassCases = {}
+
+	# es mustpass files are stored under one of the below two directories, based on if the branch as applied a folder structure change
+	# external/openglcts/data/mustpass
+	# external/openglcts/data/gl_cts/data/mustpass
+	# Get the mustpass file search path based on which folder structure the branch has
+
+	mustpassFileSearchPath = "openglcts"
+	# First find all immediate sub directories of external/openglcts/data
+	openglctsDataPath = os.path.join(ctsPath, "external", "openglcts", "data")
+	openglctsDataChildPath = []
+	for childPath in os.listdir(openglctsDataPath):
+		if (os.path.isdir(os.path.join(openglctsDataPath, childPath))):
+			openglctsDataChildPath.append(childPath)
+	# Check if there is a single gl_cts subdirectory, use the new directory structure openglcts/data/gl_cts as the search path for mustpass files
+	if len(openglctsDataChildPath) == 1:
+		if openglctsDataChildPath[0] == "gl_cts":
+			mustpassFileSearchPath = "openglcts/data/gl_cts"
+		else:
+			report.failure("If there is only a single subdirectory under external/openglcts/data, its' name should be gl_cts")
+
 	# Verify that all run files passed
 	for runLog in summary.runLogAndCaselist:
-		mustpassFile = os.path.join(ctsPath, "external", "openglcts", summary.runLogAndCaselist[runLog])
+		mustpassFile = os.path.join(ctsPath, "external", mustpassFileSearchPath, summary.runLogAndCaselist[runLog])
 		key = os.path.dirname(mustpassFile)
 		if key in mustpassCases:
 			mpCase = mustpassCases[key]


### PR DESCRIPTION
After the change https://gerrit.khronos.org/c/vk-gl-cts/+/14240 is merged, on some branches, es mustpass files will be listed under:
external/openglcts/data/gl_cts/data/

Versus on other branches, es mustpass files remain under: external/openglcts/data/

Add the code in verify_es.py script to set the path of es mustpass files based on which folder structure above the branch has.