### PR TITLE
make missing Conformant attr in glcts submissions a warning

### DIFF
--- a/summary.py
+++ b/summary.py
@@ -22,6 +22,7 @@
 #-------------------------------------------------------------------------
 
 import xml.dom.minidom
+from report import *
 
 class TestRunSummary:
 	def __init__ (self, type, isConformant, configLogFilename, runLogFilenames, runLogAndCaselist):
@@ -31,14 +32,19 @@ class TestRunSummary:
 		self.runLogFilenames	= runLogFilenames
 		self.runLogAndCaselist	= runLogAndCaselist
 
-def parseRunSummary (filename):
+def parseRunSummary (report, filename):
 	doc = xml.dom.minidom.parse(filename)
 	summary = doc.documentElement
 	if summary.localName != "Summary":
 		raise Exception("Document element is not <Summmary>")
 
 	type			= summary.getAttributeNode("Type").nodeValue
-	isConformant	= summary.getAttributeNode("Conformant").nodeValue == "True"
+	conformantNode	= summary.getAttributeNode("Conformant")
+	isConformant	= True
+	if conformantNode:
+		isConformant	= conformantNode.nodeValue == "True"
+	else:
+		report.warning("Conformant attr not found")
 
 	configRuns		= doc.getElementsByTagName("Configs")
 	if len(configRuns) != 1:

--- a/verify_es.py
+++ b/verify_es.py
@@ -189,7 +189,7 @@ def verifyTestLogs(report, package, gitSHA, ctsPath):
 	if package.summary == None:
 		report.failure("The package is missing cts-run-summary.xml")
 		return
-	summary	= parseRunSummary(os.path.join(package.basePath, package.summary))
+	summary	= parseRunSummary(report, os.path.join(package.basePath, package.summary))
 	mustpassDirs = []
 
 	# Check Conformant attribute


### PR DESCRIPTION
this may be omitted if the submission package is generated using a parallel or distributed runner