### PR TITLE
verify_submission.py: delay git clone

### DIFF
--- a/verify_submission.py
+++ b/verify_submission.py
@@ -67,7 +67,6 @@ def parseArgs ():
 
 if __name__ == "__main__":
 	args			= parseArgs()
-	ctsPath			= validateSource(args.source)
 	report			= Report(args.verbose, args.output)
 
 	packageFile		= os.path.normpath(args.package)
@@ -106,6 +105,7 @@ if __name__ == "__main__":
 			else:
 				apiName		= API_TYPE_DICT[apiType] + ' ' + apiVersion
 
+				ctsPath      = validateSource(args.source)
 				verification = Verification(packagePath, ctsPath, apiType, apiVersion, releaseTag)
 				if isSubmissionSupported(apiType):
 					report.message("Started verification for %s" % apiName, packageFileBN)


### PR DESCRIPTION
Cloning the VK-GL-CTS repository can take a long time, so defer doing that until at least some of the sanity checks have been done (e.g. that we know the tar file is legal). This prevents the user from having to wait 5 minutes (or longer!) to discover that they've mistyped the file name.