### PR TITLE
Fix recognizing fractional logs with more than 9 fractions

### DIFF
--- a/package.py
+++ b/package.py
@@ -105,7 +105,7 @@ def getPackageDescription (report, verification):
 			if reobj.match(log) == None:
 				report.failure("Test log name does not conform to --deqp-fraction option", log)
 	for log in testLogs:
-		prefix = re.split("(\d-of-\d)+", log)[0]
+		prefix = re.split("(\d+-of-\d+)+", log)[0]
 		if prefix in testLogsFraction:
 			fractionLogs = testLogsFraction[prefix]
 		else:


### PR DESCRIPTION
Allow multiple digits for x and y in "TestResults-arch-x-of-y.qpa". This fixes validation for conformance packages with more than 9 fractions as was recently allowed.