### PR TITLE
utils: force checkout to look for a tag

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -305,7 +305,7 @@ def validateSource(ctsPath):
 def checkoutReleaseTag(report, releaseTag):
 	success = False
 	try:
-		git('checkout', releaseTag)
+		git('checkout', f'tags/{releaseTag}')
 	except:
 		report.failure("Failed to checkout release tag %s" % releaseTag)
 	else:


### PR DESCRIPTION
If there is a branch of the same name, the checkout is ambiguous. Add the `tags/` prefix to the `releaseTag`.