### PR TITLE
Add 'single' configs only when API version matches

### DIFF
--- a/verify_es.py
+++ b/verify_es.py
@@ -134,8 +134,13 @@ def verifyMustpassCases(report, package, mustpassCases, type):
 			for config in configs:
 				caseListFile = config.getAttributeNode("caseListFile").nodeValue
 				_, configVersion = getConfigVersion(report, caseListFile.split('-')[0])
-				if configVersion <= typeVersion:
-					testConfigs.append(config)
+				# Single test cases configs must be added only when API version matches to follow the same logic as in CTS runner
+				if 'single' in caseListFile:
+					if configVersion == typeVersion:
+						testConfigs.append(config)
+				else:
+					if configVersion <= typeVersion:
+						testConfigs.append(config)
 		else:
 			# For GL check for the configs which must be tested (largest version less than "type")
 			for config in configs:


### PR DESCRIPTION
`verify_submission.py` expected more tests to have been run than the CTS runner actually runs, so a correct GLES 3.2 submission failed verification.

### The bug

The runner executes a single-config caselist **only when its API version matches** the API under test: `getTestRunsForSingleConfig()` in `glcTestRunner.cpp` skips every entry where `type != runParams[i].apiType`. Regular caselists, by contrast, cascade to all lower-or-equal versions.

`verify_es.py` did not mirror that rule. For a GLES 3.2 run it expected tests from both `gles31-khr-single` and `gles32-khr-single`, even though the runner only ever runs `gles32-khr-single`. Once a `gles31-khr-single` entry was added to the mustpass in `opengl-es-cts-3.2.13.0`, a correct submission started failing verification, with the `gles31-khr-single` tests reported as missing.

### The fix

Apply the same exact-version rule to `single` configs, and leave the existing cascade in place for all other configs. Only the ES / no-context path is affected; the GL path already selects a single config version.

### Notes

- Patch authored by Bartosz Cieśla (bciesla@google.com), who reproduced the problem against a failing ES 3.2 submission and verified the fix. Authorship is preserved in the commit.
- Khronos-internal issue: https://gitlab.khronos.org/Tracker/vk-gl-cts/-/issues/6589
